### PR TITLE
BTTV fix for detecting messages

### DIFF
--- a/src/js/lib/chat.js
+++ b/src/js/lib/chat.js
@@ -19,6 +19,8 @@ var chatObserver = new MutationObserver(function processMutations(mutations) {
 		for (i = 0, l = addedNodes.length; i < l; i++) {
 			node = addedNodes[i];
 			line = node.querySelector && node.querySelector('.chat-line');
+			if (!line && node.matches && node.matches('.chat-line'))
+				line = node;  // BTTV fix;
 			if (!line) continue;
 			name = query('.from', line);
 			name = name && name.textContent.trim();


### PR DESCRIPTION
Since @night basically gave the exact solution to #7 and seeing that you seem busy, I decided to pull request the fix myself.

The solution is really simple, your code looks for `.chat-line` in the children, but in the case of BTTV, the node itself is the `.chat-line` element, so I just add an extra check for that. Everything else works perfectly fine once we have the right node.

Tested it both with and without BTTV and it works as expected.