### PR TITLE
Add popular bots to default ignore list

### DIFF
--- a/src/js/component/tga.js
+++ b/src/js/component/tga.js
@@ -21,7 +21,7 @@ app.cfgDefaults = {
 	keywordAntispam: false,
 	keywordAntispamLimit: 1,
 	displayTooltips: true,
-	ignoreList: ['jtv']
+	ignoreList: ['jtv','nightbot','moobot','vivbot','wizebot','coebot']
 };
 app.optionDefaults = {
 	storageName: 'twitchGiveaways',


### PR DESCRIPTION
To solve issue #23, added some popular bots (nightbot, moobot, vivbot, wizebot and coebot) to the default ignore list to avoid having these popular bots on giveaways :)